### PR TITLE
Include <stdio.h> for printf in .hsc files

### DIFF
--- a/src/System/Posix/Clock.hsc
+++ b/src/System/Posix/Clock.hsc
@@ -55,6 +55,7 @@ import Unsafe.Coerce (unsafeCoerce)
 #include <time.h>
 #include <HsBaseConfig.h>
 #include <posix-timer.macros.h>
+#include <stdio.h>
 
 #let alignment t = "%lu", (unsigned long) offsetof (struct { char x__; t (y__); }, y__)
 

--- a/src/System/Posix/Timer.hsc
+++ b/src/System/Posix/Timer.hsc
@@ -34,6 +34,7 @@ import System.Posix.Clock (TimeSpec, Clock(..))
 #include <time.h>
 #include <signal.h>
 #include <posix-timer.macros.h>
+#include <stdio.h>
 
 #let alignment t = "%lu", (unsigned long) offsetof (struct { char x__; t (y__); }, y__)
 


### PR DESCRIPTION
gcc-14 has `-Werror=implicit-function-declaration` on by default